### PR TITLE
DOSCT-62 Add Web Application Firewall Metrics to Dashboard

### DIFF
--- a/build/automation/var/project.mk
+++ b/build/automation/var/project.mk
@@ -100,8 +100,8 @@ TF_VAR_waf_aws_sqli_rule_name := $(PROJECT_ID)-$(ENVIRONMENT)-waf-aws-sqli-rule
 TF_VAR_waf_managed_rule_group_rule_name := $(PROJECT_ID)-$(ENVIRONMENT)-waf-managed-rule-group-rule
 # WAF Metrics
 TF_VAR_waf_acl_metric_name := $(PROJECT_ID)-$(ENVIRONMENT)-waf-acl-metric
-TF_VAR_ip_reputation_list_metric_name := $(PROJECT_ID)-$(ENVIRONMENT)-ip-reputation-list-metric
-TF_VAR_non_gb_rule_metric_name := $(PROJECT_ID)-$(ENVIRONMENT)-non-gb-rule-metric
+TF_VAR_waf_ip_reputation_list_metric_name := $(PROJECT_ID)-$(ENVIRONMENT)-waf-ip-reputation-list-metric
+TF_VAR_waf_non_gb_rule_metric_name := $(PROJECT_ID)-$(ENVIRONMENT)-waf-non-gb-rule-metric
 TF_VAR_waf_ip_allow_list_metric_name := $(PROJECT_ID)-$(ENVIRONMENT)-waf-ip-allow-list-metric
 TF_VAR_waf_rate_based_metric_name := $(PROJECT_ID)-$(ENVIRONMENT)-waf-rate-based-metric
 TF_VAR_waf_aws_known_bad_inputs_metric_name := $(PROJECT_ID)-$(ENVIRONMENT)-waf-aws-known-bad-inputs-metric

--- a/infrastructure/stacks/application/cloudwatch-alarms.tf
+++ b/infrastructure/stacks/application/cloudwatch-alarms.tf
@@ -123,7 +123,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_non_gb_alarm" {
   alarm_description   = "WAF non GB alarm"
   dimensions = {
     region   = var.aws_region,
-    RuleName = var.non_gb_rule_metric_name
+    RuleName = var.waf_non_gb_rule_metric_name
   }
 }
 

--- a/infrastructure/stacks/application/cloudwatch-dashboard.tf
+++ b/infrastructure/stacks/application/cloudwatch-dashboard.tf
@@ -77,6 +77,61 @@ resource "aws_cloudwatch_dashboard" "cloudwatch_dashboard" {
           title : "Search Lambda",
           period : 60
         }
+      },
+      {
+        height : 6,
+        width : 12,
+        y : 6,
+        x : 0,
+        type : "metric",
+        properties : {
+          sparkline : true,
+          view : "singleValue",
+          metrics : [
+            ["AWS/WAFV2", "CountedRequests", "Region", var.aws_region, "Rule", var.waf_rate_based_metric_name, "WebACL", var.api_gateway_waf_acl, { "label" : "Rate Based Rule" }],
+            ["...", var.waf_non_gb_rule_metric_name, ".", ".", { "label" : "Non GB Rule" }],
+            ["...", var.waf_aws_known_bad_inputs_metric_name, ".", ".", { "label" : "Bad Inputs Rule" }],
+            ["...", var.waf_aws_sqli_metric_name, ".", ".", { "label" : "SQL Injection Rule" }],
+            ["...", var.waf_ip_reputation_list_metric_name, ".", ".", { "label" : "IP Reputation Rule" }],
+            ["...", var.waf_managed_rule_group_metric_name, ".", ".", { "label" : "Common AWS Rules" }],
+          ],
+          stacked : false,
+          region : var.aws_region,
+          stat : "Sum",
+          title : "WAF Rule Matches"
+        }
+      },
+      {
+        height : 6,
+        width : 6,
+        y : 6,
+        x : 12,
+        type : "metric",
+        properties : {
+          metrics : [
+            ["AWS/WAFV2", "CountedRequests", "Region", "eu-west-2", "Rule", "ALL", "WebACL", var.api_gateway_waf_acl],
+            ["...", "AllowedRequests", ".", "."]
+          ],
+          period : 60,
+          region : var.aws_region,
+          stacked : false,
+          stat : "Sum",
+          title : "WAF Requests",
+          view : "gauge",
+          yAxis : {
+            left : {
+              min : 0,
+              max : 100
+            }
+          },
+          legend : {
+            position : "bottom"
+          },
+          liveData : false,
+          setPeriodToTimeRange : false,
+          sparkline : true,
+          trend : true
+        }
       }
     ]
   })

--- a/infrastructure/stacks/application/variables.tf
+++ b/infrastructure/stacks/application/variables.tf
@@ -301,7 +301,7 @@ variable "waf_rate_based_metric_name" {
   description = "WAF rate based metric name"
 }
 
-variable "non_gb_rule_metric_name" {
+variable "waf_non_gb_rule_metric_name" {
   type        = string
   description = "Non GB rule metric name"
 }
@@ -316,7 +316,7 @@ variable "waf_aws_sqli_metric_name" {
   description = "WAF AWS SQLi metric name"
 }
 
-variable "ip_reputation_list_metric_name" {
+variable "waf_ip_reputation_list_metric_name" {
   type        = string
   description = "IP reputation list metric name"
 }

--- a/infrastructure/stacks/application/waf.tf
+++ b/infrastructure/stacks/application/waf.tf
@@ -44,7 +44,7 @@ resource "aws_wafv2_web_acl" "api_gateway_waf_acl" {
     }
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = var.non_gb_rule_metric_name
+      metric_name                = var.waf_non_gb_rule_metric_name
       sampled_requests_enabled   = true
     }
   }
@@ -111,7 +111,7 @@ resource "aws_wafv2_web_acl" "api_gateway_waf_acl" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = var.ip_reputation_list_metric_name
+      metric_name                = var.waf_ip_reputation_list_metric_name
       sampled_requests_enabled   = true
     }
   }


### PR DESCRIPTION
# Task Branch Pull Request

## Description of Changes

This PR adds the metrics for the WAF rules to the CloudWatch Dashboard
